### PR TITLE
Add new TH & VN date translations

### DIFF
--- a/default_formats.go
+++ b/default_formats.go
@@ -10,216 +10,252 @@ const (
 	DefaultFormatEnUSMedium   = "Jan 02, 2006"
 	DefaultFormatEnUSShort    = "1/2/06"
 	DefaultFormatEnUSDateTime = "1/2/06 3:04 PM"
+	DefaultFormatEnUSTime     = "3:04 PM"
 
 	DefaultFormatEnGBFull     = "Monday, 2 January 2006" // English (United Kingdom)
 	DefaultFormatEnGBLong     = "2 January 2006"
 	DefaultFormatEnGBMedium   = "02 Jan 2006"
 	DefaultFormatEnGBShort    = "02/01/2006"
 	DefaultFormatEnGBDateTime = "02/01/2006 15:04"
+	DefaultFormatEnGBTime     = "15:04"
 
 	DefaultFormatDaDKFull     = "Monday den 2. January 2006" // Danish (Denmark)
 	DefaultFormatDaDKLong     = "2. Jan 2006"
 	DefaultFormatDaDKMedium   = "02/01/2006"
 	DefaultFormatDaDKShort    = "02/01/06"
 	DefaultFormatDaDKDateTime = "02/01/2006 15.04"
+	DefaultFormatDaDKTime     = "15.04"
 
 	DefaultFormatNlBEFull     = "Monday 2 January 2006" // Dutch (Belgium)
 	DefaultFormatNlBELong     = "2 January 2006"
 	DefaultFormatNlBEMedium   = "02-Jan-2006"
 	DefaultFormatNlBEShort    = "2/01/06"
 	DefaultFormatNlBEDateTime = "2/01/06 15:04"
+	DefaultFormatNlBETime     = "15:04"
 
 	DefaultFormatNlNLFull     = "Monday 2 January 2006" // Dutch (Netherlands)
 	DefaultFormatNlNLLong     = "2 January 2006"
 	DefaultFormatNlNLMedium   = "02 Jan 2006"
 	DefaultFormatNlNLShort    = "02-01-06"
 	DefaultFormatNlNLDateTime = "02-01-06 15:04"
+	DefaultFormatNlNLTime     = "15:04"
 
 	DefaultFormatFiFIFull     = "Monday 2. January 2006" // Finnish (Finland)
 	DefaultFormatFiFILong     = "2. January 2006"
 	DefaultFormatFiFIMedium   = "02.1.2006"
 	DefaultFormatFiFIShort    = "02.1.2006"
 	DefaultFormatFiFIDateTime = "02.1.2006 15.04"
+	DefaultFormatFiFITime     = "15.04"
 
 	DefaultFormatFrFRFull     = "Monday 2 January 2006" // French (France)
 	DefaultFormatFrFRLong     = "2 January 2006"
 	DefaultFormatFrFRMedium   = "02 Jan 2006"
 	DefaultFormatFrFRShort    = "02/01/2006"
 	DefaultFormatFrFRDateTime = "02/01/2006 15:04"
+	DefaultFormatFrFRTime     = "15:04"
 
 	DefaultFormatFrCAFull     = "Monday 2 January 2006" // French (Canada)
 	DefaultFormatFrCALong     = "2 January 2006"
 	DefaultFormatFrCAMedium   = "2006-01-02"
 	DefaultFormatFrCAShort    = "06-01-02"
 	DefaultFormatFrCADateTime = "06-01-02 15:04"
+	DefaultFormatFrCATime     = "15:04"
 
 	DefaultFormatFrGPFull     = "Monday 2 January 2006" // French (Guadeloupe)
 	DefaultFormatFrGPLong     = "2 January 2006"
 	DefaultFormatFrGPMedium   = "2006-01-02"
 	DefaultFormatFrGPShort    = "06-01-02"
 	DefaultFormatFrGPDateTime = "06-01-02 15:04"
+	DefaultFormatFrGPTime     = "15:04"
 
 	DefaultFormatFrLUFull     = "Monday 2 January 2006" // French (Luxembourg)
 	DefaultFormatFrLULong     = "2 January 2006"
 	DefaultFormatFrLUMedium   = "2006-01-02"
 	DefaultFormatFrLUShort    = "06-01-02"
 	DefaultFormatFrLUDateTime = "06-01-02 15:04"
+	DefaultFormatFrLUTime     = "15:04"
 
 	DefaultFormatFrMQFull     = "Monday 2 January 2006" // French (Martinique)
 	DefaultFormatFrMQLong     = "2 January 2006"
 	DefaultFormatFrMQMedium   = "2006-01-02"
 	DefaultFormatFrMQShort    = "06-01-02"
 	DefaultFormatFrMQDateTime = "06-01-02 15:04"
+	DefaultFormatFrMQTime     = "15:04"
 
 	DefaultFormatFrGFFull     = "Monday 2 January 2006" // French (French Guiana)
 	DefaultFormatFrGFLong     = "2 January 2006"
 	DefaultFormatFrGFMedium   = "2006-01-02"
 	DefaultFormatFrGFShort    = "06-01-02"
 	DefaultFormatFrGFDateTime = "06-01-02 15:04"
+	DefaultFormatFrGFTime     = "15:04"
 
 	DefaultFormatFrREFull     = "Monday 2 January 2006" // French (Reunion)
 	DefaultFormatFrRELong     = "2 January 2006"
 	DefaultFormatFrREMedium   = "2006-01-02"
 	DefaultFormatFrREShort    = "06-01-02"
 	DefaultFormatFrREDateTime = "06-01-02 15:04"
+	DefaultFormatFrRETime     = "15:04"
 
 	DefaultFormatDeDEFull     = "Monday, 2. January 2006" // German (Germany)
 	DefaultFormatDeDELong     = "2. January 2006"
 	DefaultFormatDeDEMedium   = "02.01.2006"
 	DefaultFormatDeDEShort    = "02.01.06"
 	DefaultFormatDeDEDateTime = "02.01.06 15:04"
+	DefaultFormatDeDETime     = "15:04"
 
 	DefaultFormatHuHUFull     = "2006. January 2., Monday" // Hungarian (Hungary)
 	DefaultFormatHuHULong     = "2006. January 2."
 	DefaultFormatHuHUMedium   = "2006.01.02."
 	DefaultFormatHuHUShort    = "2006.01.02."
 	DefaultFormatHuHUDateTime = "2006.01.02. 15:04"
+	DefaultFormatHuHUTime     = "15:04"
 
 	DefaultFormatItITFull     = "Monday 2 January 2006" // Italian (Italy)
 	DefaultFormatItITLong     = "2 January 2006"
 	DefaultFormatItITMedium   = "02/Jan/2006"
 	DefaultFormatItITShort    = "02/01/06"
 	DefaultFormatItITDateTime = "02/01/06 15:04"
+	DefaultFormatItITTime     = "15:04"
 
 	DefaultFormatNnNOFull     = "Monday 2. January 2006" // Norwegian Nynorsk (Norway)
 	DefaultFormatNnNOLong     = "2. January 2006"
 	DefaultFormatNnNOMedium   = "02. Jan 2006"
 	DefaultFormatNnNOShort    = "02.01.06"
 	DefaultFormatNnNODateTime = "02.01.06 15:04"
+	DefaultFormatNnNOTime     = "15:04"
 
 	DefaultFormatNbNOFull     = "Monday 2. January 2006" // Norwegian Bokmål (Norway)
 	DefaultFormatNbNOLong     = "2. January 2006"
 	DefaultFormatNbNOMedium   = "02. Jan 2006"
 	DefaultFormatNbNOShort    = "02.01.06"
 	DefaultFormatNbNODateTime = "15:04 02.01.06"
+	DefaultFormatNbNOTime     = "15:04"
 
 	DefaultFormatPtPTFull     = "Monday, 2 de January de 2006" // Portuguese (Portugal)
 	DefaultFormatPtPTLong     = "2 de January de 2006"
 	DefaultFormatPtPTMedium   = "02/01/2006"
 	DefaultFormatPtPTShort    = "02/01/06"
 	DefaultFormatPtPTDateTime = "02/01/06, 15:04"
+	DefaultFormatPtPTTime     = "15:04"
 
 	DefaultFormatPtBRFull     = "Monday, 2 de January de 2006" // Portuguese (Brazil)
 	DefaultFormatPtBRLong     = "02 de January de 2006"
 	DefaultFormatPtBRMedium   = "02/01/2006"
 	DefaultFormatPtBRShort    = "02/01/06"
 	DefaultFormatPtBRDateTime = "02/01/06, 15:04"
+	DefaultFormatPtBRTime     = "15:04"
 
 	DefaultFormatRoROFull     = "Monday, 02 January 2006" // Romanian (Romania)
 	DefaultFormatRoROLong     = "02 January 2006"
 	DefaultFormatRoROMedium   = "02.01.2006"
 	DefaultFormatRoROShort    = "02.01.2006"
 	DefaultFormatRoRODateTime = "02.01.06, 15:04"
+	DefaultFormatRoROTime     = "15:04"
 
 	DefaultFormatRuRUFull     = "Monday, 2 January 2006 г." // Russian (Russia)
 	DefaultFormatRuRULong     = "2 January 2006 г."
 	DefaultFormatRuRUMedium   = "02 Jan 2006 г."
 	DefaultFormatRuRUShort    = "02.01.06"
 	DefaultFormatRuRUDateTime = "02.01.06, 15:04"
+	DefaultFormatRuRUTime     = "15:04"
 
 	DefaultFormatEsESFull     = "Monday, 2 de January de 2006" // Spanish (Spain)
 	DefaultFormatEsESLong     = "2 de January de 2006"
 	DefaultFormatEsESMedium   = "02/01/2006"
 	DefaultFormatEsESShort    = "02/01/06"
 	DefaultFormatEsESDateTime = "02/01/06 15:04"
+	DefaultFormatEsESTime     = "15:04"
 
 	DefaultFormatCaESFull     = "Monday, 2 de January de 2006" // Spanish (Spain)
 	DefaultFormatCaESLong     = "2 de January de 2006"
 	DefaultFormatCaESMedium   = "02/01/2006"
 	DefaultFormatCaESShort    = "02/01/06"
 	DefaultFormatCaESDateTime = "02/01/06 15:04"
+	DefaultFormatCaESTime     = "15:04"
 
 	DefaultFormatSvSEFull     = "Mondayen den 2:e January 2006" // Swedish (Sweden)
 	DefaultFormatSvSELong     = "2 January 2006"
 	DefaultFormatSvSEMedium   = "2 Jan 2006"
 	DefaultFormatSvSEShort    = "2006-01-02"
 	DefaultFormatSvSEDateTime = "2006-01-02 15:04"
+	DefaultFormatSvSETime     = "15:04"
 
 	DefaultFormatTrTRFull     = "2 January 2006 Monday" // Turkish (Turkey)
 	DefaultFormatTrTRLong     = "2 January 2006"
 	DefaultFormatTrTRMedium   = "2 Jan 2006"
 	DefaultFormatTrTRShort    = "2.01.2006"
 	DefaultFormatTrTRDateTime = "2.01.2006 15:04"
+	DefaultFormatTrTRTime     = "15:04"
 
 	DefaultFormatUkUAFull     = "Monday, 2 January 2006 р." // Ukrainian (Ukraine)
 	DefaultFormatUkUALong     = "2 January 2006 р."
 	DefaultFormatUkUAMedium   = "02 Jan 2006 р."
 	DefaultFormatUkUAShort    = "02.01.06"
 	DefaultFormatUkUADateTime = "02.01.06, 15:04"
+	DefaultFormatUkUATime     = "15:04"
 
 	DefaultFormatBgBGFull     = "Monday, 2 January 2006" // Bulgarian (Bulgaria)
 	DefaultFormatBgBGLong     = "2 January 2006"
 	DefaultFormatBgBGMedium   = "2 Jan 2006"
 	DefaultFormatBgBGShort    = "2.01.2006"
 	DefaultFormatBgBGDateTime = "2.01.2006 15:04"
+	DefaultFormatBgBGTime     = "15:04"
 
 	DefaultFormatZhCNFull     = "2006年1月2日 Monday" // Chinese (Mainland)
 	DefaultFormatZhCNLong     = "2006年1月2日"
 	DefaultFormatZhCNMedium   = "2006-01-02"
 	DefaultFormatZhCNShort    = "2006/1/2"
 	DefaultFormatZhCNDateTime = "2006-01-02 15:04"
+	DefaultFormatZhCNTime     = "15:04"
 
 	DefaultFormatZhTWFull     = "2006年1月2日 Monday" // Chinese (Taiwan)
 	DefaultFormatZhTWLong     = "2006年1月2日"
 	DefaultFormatZhTWMedium   = "2006-01-02"
 	DefaultFormatZhTWShort    = "2006/1/2"
 	DefaultFormatZhTWDateTime = "2006-01-02 15:04"
+	DefaultFormatZhTWTime     = "15:04"
 
 	DefaultFormatZhHKFull     = "2006年1月2日 Monday" // Chinese (Hong Kong)
 	DefaultFormatZhHKLong     = "2006年1月2日"
 	DefaultFormatZhHKMedium   = "2006-01-02"
 	DefaultFormatZhHKShort    = "2006/1/2"
 	DefaultFormatZhHKDateTime = "2006-01-02 15:04"
+	DefaultFormatZhHKTime     = "15:04"
 
 	DefaultFormatKoKRFull     = "2006년1월2일 월요일" // Korean (Korea)
 	DefaultFormatKoKRLong     = "2006년1월2일"
 	DefaultFormatKoKRMedium   = "2006-01-02"
 	DefaultFormatKoKRShort    = "2006/1/2"
 	DefaultFormatKoKRDateTime = "2006-01-02 15:04"
+	DefaultFormatKoKRTime     = "15:04"
 
 	DefaultFormatJaJPFull     = "2006年1月2日 Monday" // Japanese (Japan)
 	DefaultFormatJaJPLong     = "2006年1月2日"
 	DefaultFormatJaJPMedium   = "2006/01/02"
 	DefaultFormatJaJPShort    = "2006/1/2"
 	DefaultFormatJaJPDateTime = "2006/01/02 15:04"
+	DefaultFormatJaJPTime     = "15:04"
 
 	DefaultFormatElGRFull     = "Monday, 2 January 2006" // Greek (Greece)
 	DefaultFormatElGRLong     = "2 January 2006"
 	DefaultFormatElGRMedium   = "2 Jan 2006"
 	DefaultFormatElGRShort    = "02/01/06"
 	DefaultFormatElGRDateTime = "02/01/06 15:04"
+	DefaultFormatElGRTime     = "15:04"
 
 	DefaultFormatCsCZFull     = "Monday, 2. January 2006" // Czech (Czech Republic)
 	DefaultFormatCsCZLong     = "2. January 2006"
 	DefaultFormatCsCZMedium   = "02 Jan 2006"
 	DefaultFormatCsCZShort    = "02/01/2006"
 	DefaultFormatCsCZDateTime = "02/01/2006 15:04"
+	DefaultFormatCsCZTime     = "15:04"
 
 	DefaultFormatLtLTFull     = "2006 m. January 2 d., Monday" // Lithuanian (Lithuania)
 	DefaultFormatLtLTLong     = "2006 January 2 d."
 	DefaultFormatLtLTMedium   = "2006 Jan 2"
 	DefaultFormatLtLTShort    = "2006-01-02"
 	DefaultFormatLtLTDateTime = "2006-01-02, 15:04"
+	DefaultFormatLtLTTime     = "15:04"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all
@@ -259,7 +295,7 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleJaJP: DefaultFormatJaJPFull,
 	LocaleElGR: DefaultFormatElGRFull,
 	LocaleCsCZ: DefaultFormatCsCZFull,
-	LocaleUkUA: DefaultFormatUkUAFull,	
+	LocaleUkUA: DefaultFormatUkUAFull,
 	LocaleLtLT: DefaultFormatLtLTFull,
 }
 
@@ -425,4 +461,45 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZDateTime,
 	LocaleUkUA: DefaultFormatUkUADateTime,
 	LocaleLtLT: DefaultFormatLtLTDateTime,
+}
+
+// TimeFormatsByLocale maps locales to the 'Time' date formats for
+// all supported locales.
+var TimeFormatsByLocale = map[Locale]string{
+	LocaleEnUS: DefaultFormatEnUSTime,
+	LocaleEnGB: DefaultFormatEnGBTime,
+	LocaleDaDK: DefaultFormatDaDKTime,
+	LocaleNlBE: DefaultFormatNlBETime,
+	LocaleNlNL: DefaultFormatNlNLTime,
+	LocaleFiFI: DefaultFormatFiFITime,
+	LocaleFrFR: DefaultFormatFrFRTime,
+	LocaleFrCA: DefaultFormatFrCATime,
+	LocaleFrGP: DefaultFormatFrGPTime,
+	LocaleFrLU: DefaultFormatFrLUTime,
+	LocaleFrMQ: DefaultFormatFrMQTime,
+	LocaleFrGF: DefaultFormatFrGFTime,
+	LocaleFrRE: DefaultFormatFrRETime,
+	LocaleDeDE: DefaultFormatDeDETime,
+	LocaleHuHU: DefaultFormatHuHUTime,
+	LocaleItIT: DefaultFormatItITTime,
+	LocaleNnNO: DefaultFormatNnNOTime,
+	LocaleNbNO: DefaultFormatNbNOTime,
+	LocalePtPT: DefaultFormatPtPTTime,
+	LocalePtBR: DefaultFormatPtBRTime,
+	LocaleRoRO: DefaultFormatRoROTime,
+	LocaleRuRU: DefaultFormatRuRUTime,
+	LocaleEsES: DefaultFormatEsESTime,
+	LocaleCaES: DefaultFormatCaESTime,
+	LocaleSvSE: DefaultFormatSvSETime,
+	LocaleTrTR: DefaultFormatTrTRTime,
+	LocaleBgBG: DefaultFormatBgBGTime,
+	LocaleZhCN: DefaultFormatZhCNTime,
+	LocaleZhTW: DefaultFormatZhTWTime,
+	LocaleZhHK: DefaultFormatZhHKTime,
+	LocaleKoKR: DefaultFormatKoKRTime,
+	LocaleJaJP: DefaultFormatJaJPTime,
+	LocaleElGR: DefaultFormatElGRTime,
+	LocaleCsCZ: DefaultFormatCsCZTime,
+	LocaleUkUA: DefaultFormatUkUATime,
+	LocaleLtLT: DefaultFormatLtLTTime,
 }

--- a/default_formats.go
+++ b/default_formats.go
@@ -256,6 +256,18 @@ const (
 	DefaultFormatLtLTShort    = "2006-01-02"
 	DefaultFormatLtLTDateTime = "2006-01-02, 15:04"
 	DefaultFormatLtLTTime     = "15:04"
+
+	DefaultFormatThTHFull     = "Monday, 2 January 2006" // Thai (Thailand)
+	DefaultFormatThTHLong     = "2 January 2006"
+	DefaultFormatThTHMedium   = "2 Jan 2006"
+	DefaultFormatThTHShort    = "2/1/2006"
+	DefaultFormatThTHDateTime = "2/1/2006 3:04 PM"
+
+	DefaultFormatVnVNFull     = "Monday, 2 January 2006" // Vietnamese (Vietnam)
+	DefaultFormatVnVNLong     = "2 January 2006"
+	DefaultFormatVnVNMedium   = "2 Jan 2006"
+	DefaultFormatVnVNShort    = "2/1/2006"
+	DefaultFormatVnVNDateTime = "2/1/2006 3:04 PM"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all

--- a/default_formats.go
+++ b/default_formats.go
@@ -262,12 +262,14 @@ const (
 	DefaultFormatThTHMedium   = "2 Jan 2006"
 	DefaultFormatThTHShort    = "2/1/2006"
 	DefaultFormatThTHDateTime = "2/1/2006 3:04 PM"
+	DefaultFormatThTHTime     = "15:04"
 
 	DefaultFormatVnVNFull     = "Monday, 2 January 2006" // Vietnamese (Vietnam)
 	DefaultFormatVnVNLong     = "2 January 2006"
 	DefaultFormatVnVNMedium   = "2 Jan 2006"
 	DefaultFormatVnVNShort    = "2/1/2006"
 	DefaultFormatVnVNDateTime = "2/1/2006 3:04 PM"
+	DefaultFormatVnVNTime     = "15:04"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all
@@ -309,6 +311,8 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZFull,
 	LocaleUkUA: DefaultFormatUkUAFull,
 	LocaleLtLT: DefaultFormatLtLTFull,
+	LocaleThTH: DefaultFormatThTHFull,
+	LocaleVnVN: DefaultFormatVnVNFull,
 }
 
 // LongFormatsByLocale maps locales to the 'long' date formats for all
@@ -350,6 +354,8 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZLong,
 	LocaleUkUA: DefaultFormatUkUALong,
 	LocaleLtLT: DefaultFormatLtLTLong,
+	LocaleThTH: DefaultFormatThTHLong,
+	LocaleVnVN: DefaultFormatVnVNLong,
 }
 
 // MediumFormatsByLocale maps locales to the 'medium' date formats for all
@@ -391,6 +397,8 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZMedium,
 	LocaleUkUA: DefaultFormatUkUAMedium,
 	LocaleLtLT: DefaultFormatLtLTMedium,
+	LocaleThTH: DefaultFormatThTHMedium,
+	LocaleVnVN: DefaultFormatVnVNMedium,
 }
 
 // ShortFormatsByLocale maps locales to the 'short' date formats for all
@@ -432,6 +440,8 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZShort,
 	LocaleUkUA: DefaultFormatUkUAShort,
 	LocaleLtLT: DefaultFormatLtLTShort,
+	LocaleThTH: DefaultFormatThTHMedium,
+	LocaleVnVN: DefaultFormatVnVNMedium,
 }
 
 // DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for
@@ -473,6 +483,8 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZDateTime,
 	LocaleUkUA: DefaultFormatUkUADateTime,
 	LocaleLtLT: DefaultFormatLtLTDateTime,
+	LocaleThTH: DefaultFormatThTHDateTime,
+	LocaleVnVN: DefaultFormatVnVNDateTime,
 }
 
 // TimeFormatsByLocale maps locales to the 'Time' date formats for
@@ -514,4 +526,6 @@ var TimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZTime,
 	LocaleUkUA: DefaultFormatUkUATime,
 	LocaleLtLT: DefaultFormatLtLTTime,
+	LocaleThTH: DefaultFormatThTHTime,
+	LocaleVnVN: DefaultFormatVnVNTime,
 }

--- a/default_formats.go
+++ b/default_formats.go
@@ -440,8 +440,8 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZShort,
 	LocaleUkUA: DefaultFormatUkUAShort,
 	LocaleLtLT: DefaultFormatLtLTShort,
-	LocaleThTH: DefaultFormatThTHMedium,
-	LocaleVnVN: DefaultFormatVnVNMedium,
+	LocaleThTH: DefaultFormatThTHShort,
+	LocaleVnVN: DefaultFormatVnVNShort,
 }
 
 // DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for

--- a/format_th_th.go
+++ b/format_th_th.go
@@ -1,0 +1,55 @@
+package monday
+
+// ============================================================
+// Format rules for "th_TH" locale: Thai (Thailand)
+// ============================================================
+
+var longDayNamesThTH = map[string]string{
+	"Sunday":    "วันอาทิตย์",
+	"Monday":    "วันจันทร์",
+	"Tuesday":   "วันอังคาร",
+	"Wednesday": "วันพุธ",
+	"Thursday":  "วันพฤหัสบดี",
+	"Friday":    "วันศุกร์",
+	"Saturday":  "วันเสาร์",
+}
+
+var shortDayNamesThTH = map[string]string{
+	"Sun": "อาทิตย์",
+	"Mon": "จันทร์",
+	"Tue": "อังคาร",
+	"Wed": "พุธ",
+	"Thu": "วันพฤหัส",
+	"Fri": "ศุกร์",
+	"Sat": "เสาร์",
+}
+
+var longMonthNamesThTH = map[string]string{
+	"January":   "มกราคม",
+	"February":  "กุมภาพันธ์",
+	"March":     "มีนาคม",
+	"April":     "เมษายน",
+	"May":       "พฤษภาคม",
+	"June":      "มิถุนายน",
+	"July":      "กรกฎาคม",
+	"August":    "สิงหาคม",
+	"September": "กันยายน",
+	"October":   "ตุลาคม",
+	"November":  "พฤศจิกายน",
+	"December":  "ธันวาคม",
+}
+
+var shortMonthNamesThTH = map[string]string{
+	"Jan": "ม.ค.",
+	"Feb": "ก.พ.",
+	"Mar": "มี.ค.",
+	"Apr": "เม.ย.",
+	"May": "พ.ค.",
+	"Jun": "มิ.ย.",
+	"Jul": "ก.ค.",
+	"Aug": "ส.ค.",
+	"Sep": "ก.ย.",
+	"Oct": "ต.ค.",
+	"Nov": "พ.ย.",
+	"Dec": "ธ.ค.",
+}

--- a/format_vn_vn.go
+++ b/format_vn_vn.go
@@ -1,0 +1,55 @@
+package monday
+
+// ============================================================
+// Format rules for "vn_VN" locale: Thailand (Thailand)
+// ============================================================
+
+var longDayNamesVnVN = map[string]string{
+	"Sunday":    "chủ nhật",
+	"Monday":    "ngày thứ hai",
+	"Tuesday":   "ngày thứ ba",
+	"Wednesday": "ngày thứ tư",
+	"Thursday":  "ngày thứ năm",
+	"Friday":    "ngày thứ sáu",
+	"Saturday":  "ngày thứ bảy",
+}
+
+var shortDayNamesVnVN = map[string]string{
+	"Sun": "chủ nhật",
+	"Mon": "thứ hai",
+	"Tue": "thứ ba",
+	"Wed": "thứ tư",
+	"Thu": "thứ năm",
+	"Fri": "thứ sáu",
+	"Sat": "thứ bảy",
+}
+
+var longMonthNamesVnVN = map[string]string{
+	"January":   "tháng một",
+	"February":  "tháng hai",
+	"March":     "tháng ba",
+	"April":     "tháng tư",
+	"May":       "tháng năm",
+	"June":      "tháng sáu",
+	"July":      "tháng bảy",
+	"August":    "tháng tám",
+	"September": "tháng chín",
+	"October":   "tháng mười",
+	"November":  "tháng mười một",
+	"December":  "tháng mười hai",
+}
+
+var shortMonthNamesVnVN = map[string]string{
+	"Jan":  "tháng một",
+	"Feb":  "tháng hai",
+	"Mar":  "tháng ba",
+	"Apr":  "tháng tư",
+	"May":  "tháng năm",
+	"Jun":  "tháng sáu",
+	"Jul":  "tháng bảy",
+	"Aug":  "tháng tám",
+	"Sept": "tháng chín",
+	"Oct":  "tháng mười",
+	"Nov":  "tháng mười một",
+	"Dec":  "tháng mười hai",
+}

--- a/locale.go
+++ b/locale.go
@@ -46,6 +46,8 @@ const (
 	LocaleCsCZ = "cs_CZ" // Czech (Czech Republic)
 	LocaleSlSI = "sl_SI" // Slovenian (Slovenia)
 	LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
+	LocaleThTH = "th_TH" // Thai (Thailand)
+	LocaleVnVN = "vn_VN" // Vietnamese (Vietname)
 )
 
 // ListLocales returns all locales supported by the package.
@@ -89,5 +91,7 @@ func ListLocales() []Locale {
 		LocaleCsCZ,
 		LocaleSlSI,
 		LocaleLtLT,
+		LocaleThTH,
+		LocaleVnVN,
 	}
 }

--- a/monday.go
+++ b/monday.go
@@ -48,6 +48,8 @@ var internalFormatFuncs = map[Locale]internalFormatFunc{
 	LocaleCsCZ: createCommonFormatFunc(LocaleCsCZ),
 	LocaleSlSI: createCommonFormatFunc(LocaleSlSI),
 	LocaleLtLT: createCommonFormatFuncWithGenitive(LocaleLtLT),
+	LocaleThTH: createCommonFormatFunc(LocaleThTH),
+	LocaleVnVN: createCommonFormatFunc(LocaleVnVN),
 }
 
 // internalParseFunc is a preprocessor for default time.ParseInLocation func
@@ -93,6 +95,8 @@ var internalParseFuncs = map[Locale]internalParseFunc{
 	LocaleCsCZ: createCommonParseFunc(LocaleCsCZ),
 	LocaleSlSI: createCommonParseFunc(LocaleSlSI),
 	LocaleLtLT: createCommonParsetFuncWithGenitive(LocaleLtLT),
+	LocaleThTH: createCommonParseFunc(LocaleThTH),
+	LocaleVnVN: createCommonParseFunc(LocaleVnVN),
 }
 
 var knownDaysShort = map[Locale]map[string]string{}           // Mapping for 'Format', days of week, short form
@@ -365,6 +369,18 @@ func fillKnownWords() {
 	fillKnownMonthsShort(shortMonthNamesLtLT, LocaleLtLT)
 	fillKnownMonthsGenitiveLong(longMonthNamesGenitiveLtLT, LocaleLtLT)
 	fillKnownMonthsGenitiveShort(shortMonthNamesGenitiveLtLT, LocaleLtLT)
+
+	// Th_TH: Thai (Thailand)
+	fillKnownDaysLong(longDayNamesThTH, LocaleThTH)
+	fillKnownDaysShort(shortDayNamesThTH, LocaleThTH)
+	fillKnownMonthsLong(longMonthNamesThTH, LocaleThTH)
+	fillKnownMonthsShort(shortMonthNamesThTH, LocaleThTH)
+
+	// Vn_VN: Vietnamese (Vietnam)
+	fillKnownDaysLong(longDayNamesVnVN, LocaleVnVN)
+	fillKnownDaysShort(shortDayNamesVnVN, LocaleVnVN)
+	fillKnownMonthsLong(longMonthNamesVnVN, LocaleVnVN)
+	fillKnownMonthsShort(shortMonthNamesVnVN, LocaleVnVN)
 }
 
 func fill(src map[string]string, dest map[Locale]map[string]string, locale Locale) {


### PR DESCRIPTION
Adds:
- New Locale date format for thailand (TH)
- New Locale date format for vietnam (VN)

Tested On Local:
<img width="881" alt="Screen Shot 2022-04-19 at 10 18 53" src="https://user-images.githubusercontent.com/103980070/163938140-ad9e431c-233f-4635-9c7f-cfb5fde093f8.png">
